### PR TITLE
Update ngx-colors-trigger.directive.ts opacity on [disabled] change

### DIFF
--- a/projects/ngx-colors/src/lib/directives/ngx-colors-trigger.directive.ts
+++ b/projects/ngx-colors/src/lib/directives/ngx-colors-trigger.directive.ts
@@ -100,7 +100,7 @@ export class NgxColorsTriggerDirective implements ControlValueAccessor {
 
   public setDisabledState(isDisabled: boolean): void {
     this.isDisabled = isDisabled;
-    this.triggerRef.nativeElement.style.opacity = isDisabled ? 0.5 : undefined;
+    this.triggerRef.nativeElement.style.opacity = isDisabled ? 0.5 : 1;
   }
 
   public setColor(color) {


### PR DESCRIPTION
Opacity 0.5 is not removed when disabled is set to false.