### PR TITLE
Prevent modal to automatically close after selecting color; accept button added.

### DIFF
--- a/projects/ngx-colors/src/lib/components/panel/panel.component.html
+++ b/projects/ngx-colors/src/lib/components/panel/panel.component.html
@@ -136,5 +136,8 @@
         #paintInput
       />
     </div>
+    <button (click)="emitClose('accept')" style="float: right; margin-left: 5px;">
+      {{ acceptLabel }}
+    </button>
   </div>
 </div>

--- a/projects/ngx-colors/src/lib/components/panel/panel.component.ts
+++ b/projects/ngx-colors/src/lib/components/panel/panel.component.ts
@@ -324,7 +324,6 @@ export class PanelComponent implements OnInit {
   public changeColor(color: string): void {
     this.setColor(this.service.stringToHsva(color));
     // this.triggerInstance.onChange();
-    this.emitClose("accept");
   }
 
   public onChangeColorPicker(event: Hsva) {


### PR DESCRIPTION
When selecting a color from the modal, it automatically closes the modal, User should see how would this color look like, so rather than automatically closing the modal, accept button is added. When the user clicks on the accept button, it will close the modal.