### PR TITLE
fix: control is not pristine in template driven forms

### DIFF
--- a/projects/ngx-colors/src/lib/directives/ngx-colors-trigger.directive.spec.ts
+++ b/projects/ngx-colors/src/lib/directives/ngx-colors-trigger.directive.spec.ts
@@ -1,8 +1,192 @@
 import { NgxColorsTriggerDirective } from './ngx-colors-trigger.directive';
+import { ChangeDetectionStrategy, Component, ViewChild } from '@angular/core';
+import { NgxColorsModule } from '../ngx-colors.module';
+import { NgxColorsComponent } from '../ngx-colors.component';
+import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+
 
 describe('NgxColorsTriggerDirective', () => {
-  it('should create an instance', () => {
-    const directive = new NgxColorsTriggerDirective();
-    expect(directive).toBeTruthy();
-  });
+
+    const COLOR_PALETTE: string[] = [
+        '#F44336',
+        '#E91E63',
+        '#9C27B0',
+        '#673AB7',
+        '#3F51B5',
+        '#2196F3',
+        '#03A9F4',
+        '#00BCD4',
+        '#009688',
+        '#4CAF50',
+        '#8BC34A',
+        '#CDDC39',
+        '#FFEB3B',
+        '#FFC107',
+        '#FF9800',
+        '#FF5722',
+        '#795548',
+        '#9E9E9E',
+        '#607D8B',
+    ];
+
+    describe('a ngx-colors control in a template driven form', () => {
+
+        @Component({
+            template: `
+                <form #form="ngForm">
+                    <ngx-colors ngx-colors-trigger
+                                name="color"
+                                [(ngModel)]="color"
+                                format="hex"
+                                [palette]="COLOR_PALETTE"/>
+                </form>
+            `,
+            standalone: true,
+            changeDetection: ChangeDetectionStrategy.Default,
+            imports: [
+                NgxColorsModule,
+                FormsModule,
+            ]
+        })
+        class TestHostComponent {
+            @ViewChild(NgxColorsComponent)
+            public component!: NgxColorsComponent;
+
+            public color: string | null | undefined = undefined;
+            public readonly COLOR_PALETTE = COLOR_PALETTE;
+        }
+
+        let hostComponent: TestHostComponent;
+        let fixture: ComponentFixture<TestHostComponent>;
+        const testHostComponent = TestHostComponent;
+
+        beforeEach(async () => {
+            await TestBed.configureTestingModule({
+                providers: [
+                    provideNoopAnimations(),
+                ],
+            }).compileComponents();
+
+            fixture = TestBed.createComponent(testHostComponent);
+            hostComponent = fixture.componentInstance;
+            fixture.detectChanges();
+            hostComponent.component.ngOnInit();
+            await waitForChanges(fixture);
+        });
+
+        it('should be pristine when initialized with non-null value', async () => {
+            const debugElement = getFormDebugElement(fixture);
+            expect(debugElement.nativeElement).toHaveClass('ng-pristine');
+        });
+
+        it('should be pristine when input changes programmatically', async () => {
+            hostComponent.color = '#dc3545';
+
+            await waitForChanges(fixture);
+
+            const debugElement = getFormDebugElement(fixture);
+            expect(debugElement.nativeElement).toHaveClass('ng-pristine');
+        });
+
+        it('should be dirty when the user changes the value via the panel', async () => {
+            const directive = fixture.debugElement.query(By.directive(NgxColorsTriggerDirective));
+            directive.triggerEventHandler('click');
+            await waitForChanges(fixture);
+
+            document.querySelectorAll('.circle.color.circle-border')[0].dispatchEvent(new Event('click'));
+            await waitForChanges(fixture);
+
+            const debugElement = getFormDebugElement(fixture);
+            expect(debugElement.nativeElement).toHaveClass('ng-touched');
+            expect(debugElement.nativeElement).toHaveClass('ng-dirty');
+        });
+    });
+
+    describe('a ngx-colors control in a reactive form', () => {
+
+        @Component({
+            template: `
+                <form [formGroup]="form">
+                    <ngx-colors ngx-colors-trigger
+                                formControlName="color"
+                                format="hex"
+                                [palette]="COLOR_PALETTE"/>
+                </form>
+            `,
+            standalone: true,
+            changeDetection: ChangeDetectionStrategy.Default,
+            imports: [
+                NgxColorsModule,
+                ReactiveFormsModule,
+            ],
+        })
+        class TestHostComponent {
+            @ViewChild(NgxColorsComponent)
+            public component!: NgxColorsComponent;
+
+            public readonly COLOR_PALETTE = COLOR_PALETTE;
+
+            public form = new FormGroup({
+                color: new FormControl(undefined)
+            });
+            protected readonly undefined = undefined;
+        }
+
+        let hostComponent: TestHostComponent;
+        let fixture: ComponentFixture<TestHostComponent>;
+        const testHostComponent = TestHostComponent;
+
+        beforeEach(async () => {
+            await TestBed.configureTestingModule({
+                providers: [
+                    provideNoopAnimations(),
+                ],
+            }).compileComponents();
+
+            fixture = TestBed.createComponent(testHostComponent);
+            hostComponent = fixture.componentInstance;
+            fixture.detectChanges();
+            hostComponent.component.ngOnInit();
+            await waitForChanges(fixture);
+        });
+
+        it('should be pristine when initialized with non-null value', async () => {
+            const debugElement = getFormDebugElement(fixture);
+            expect(debugElement.nativeElement).toHaveClass('ng-pristine');
+        });
+
+        it('should be pristine when input changes programmatically', async () => {
+            hostComponent.form.controls.color.setValue('#dc3545');
+            await waitForChanges(fixture);
+
+            const debugElement = getFormDebugElement(fixture);
+            expect(debugElement.nativeElement).toHaveClass('ng-pristine');
+        });
+
+        it('should be dirty when the user changes the value via the panel', async () => {
+            const directive = fixture.debugElement.query(By.directive(NgxColorsTriggerDirective));
+            directive.triggerEventHandler('click');
+            await waitForChanges(fixture);
+
+            document.querySelectorAll('.circle.color.circle-border')[0].dispatchEvent(new Event('click'));
+            await waitForChanges(fixture);
+
+            const debugElement = getFormDebugElement(fixture);
+            expect(debugElement.nativeElement).toHaveClass('ng-touched');
+            expect(debugElement.nativeElement).toHaveClass('ng-dirty');
+        });
+    });
+
+    async function waitForChanges(fixture: ComponentFixture<any>) {
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+    }
+
+    function getFormDebugElement(fixture: ComponentFixture<any>) {
+        return fixture.debugElement.query(By.css('form'));
+    }
 });

--- a/projects/ngx-colors/src/lib/directives/ngx-colors-trigger.directive.ts
+++ b/projects/ngx-colors/src/lib/directives/ngx-colors-trigger.directive.ts
@@ -99,10 +99,6 @@ export class NgxColorsTriggerDirective implements ControlValueAccessor {
     this.close.emit(this.color);
   }
 
-  public onChange() {
-    this.onChangeCallback(this.color);
-  }
-
   public setDisabledState(isDisabled: boolean): void {
     this.isDisabled = isDisabled;
     this.triggerRef.nativeElement.style.opacity = isDisabled ? 0.5 : 1;
@@ -110,6 +106,7 @@ export class NgxColorsTriggerDirective implements ControlValueAccessor {
 
   public setColor(color) {
     this.writeValue(color);
+    this.onChangeCallback(color);
     this.input.emit(color);
   }
 
@@ -129,7 +126,6 @@ export class NgxColorsTriggerDirective implements ControlValueAccessor {
   writeValue(value) {
     if (value !== this.color) {
       this.color = value;
-      this.onChange();
       this.change.emit(value);
     }
   }


### PR DESCRIPTION
Hi, thanks for sharing your color picker library.

I found a problem in the implementation of the ControlValueAccessor, which is most noticeable in template driven forms.
When you bind a model value via a non-null default, the control (and thus the entire form) is not pristine. 
The problem is, that you are calling the onChange callback in the writeValue method. The onChange callback is supposed to be called when the view wants to update the model. See https://angular.io/api/forms/ControlValueAccessor#registeronchange

I've added some unit tests to highlight the problem and implemented a fix.

I wasn't sure about the projects code style, since tslint is demanding one style but implemented is another (e.g. quote marks). Let me know if you want me to adjust anything.