### PR TITLE
fix: remove @angular/animations dependency

### DIFF
--- a/projects/ngx-colors/package.json
+++ b/projects/ngx-colors/package.json
@@ -6,7 +6,6 @@
   "peerDependencies": {
     "@angular/common": ">=15.0.0",
     "@angular/core": ">=15.0.0",
-    "@angular/animations": ">=15.0.0",
     "@angular/forms": ">=15.0.0"
   },
   "author": "Krone",

--- a/projects/ngx-colors/src/lib/components/panel/panel.component.html
+++ b/projects/ngx-colors/src/lib/components/panel/panel.component.html
@@ -1,6 +1,12 @@
 <div class="opened" [style]="positionString" #dialog>
   <ng-container *ngIf="menu == 1">
-    <div class="colors" [@colorsAnimation]="colorsAnimationEffect">
+    <div
+      class="colors"
+      [ngClass]="{
+        'slide-in': colorsAnimationEffect === 'slide-in',
+        'popup': colorsAnimationEffect === 'popup'
+      }"
+    >
       <ng-container *ngFor="let color of palette; let i = index">
         <div class="circle wrapper color">
           <div
@@ -56,7 +62,13 @@
     </div>
   </ng-container>
   <ng-container *ngIf="menu == 2">
-    <div class="colors" [@colorsAnimation]="colorsAnimationEffect">
+    <div
+      class="colors"
+      [ngClass]="{
+        'slide-in': colorsAnimationEffect === 'slide-in',
+        'popup': colorsAnimationEffect === 'popup'
+      }"
+    >
       <div class="circle wrapper">
         <div (click)="onClickBack()" class="add">
           <svg

--- a/projects/ngx-colors/src/lib/components/panel/panel.component.scss
+++ b/projects/ngx-colors/src/lib/components/panel/panel.component.scss
@@ -111,6 +111,30 @@ $radius: 5px;
     }
   }
 
+  // Staggered enter animation for the palette swatches. Replaces the legacy
+  // @angular/animations `colorsAnimation` trigger with pure CSS so the library
+  // no longer requires an animations provider at the consumer's bootstrap.
+  // The animation class (`slide-in` | `popup`) is set from `colorsAnimationEffect`.
+  .colors {
+    &.slide-in > * {
+      animation: ngx-colors-slide-in 0.3s ease-in both;
+    }
+    &.popup > * {
+      animation: ngx-colors-popup 0.5s ease-out both;
+    }
+
+    // Reproduce the original 10ms-per-item stagger via incremental delays.
+    // The cap (200) only bounds how many swatches get a *staggered* delay;
+    // swatch 201+ still animate, just without an extra per-item offset. 200 is
+    // well beyond any realistic palette while keeping the generated CSS small.
+    @for $i from 1 through 200 {
+      &.slide-in > *:nth-child(#{$i}),
+      &.popup > *:nth-child(#{$i}) {
+        animation-delay: #{($i - 1) * 10}ms;
+      }
+    }
+  }
+
   .color-picker-wrapper {
     margin: 5px 15px 5px 15px;
   }
@@ -168,3 +192,37 @@ $radius: 5px;
   }
 }
 // }
+
+@keyframes ngx-colors-slide-in {
+  0% {
+    opacity: 0;
+    transform: translateX(-50%);
+  }
+  30% {
+    opacity: 0.5;
+    transform: translateX(-10px) scale(1.1);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes ngx-colors-popup {
+  0% {
+    opacity: 0;
+    transform: scale(0);
+  }
+  30% {
+    opacity: 0.5;
+    transform: scale(0.5);
+  }
+  80% {
+    opacity: 1;
+    transform: scale(1.1);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}

--- a/projects/ngx-colors/src/lib/components/panel/panel.component.ts
+++ b/projects/ngx-colors/src/lib/components/panel/panel.component.ts
@@ -10,15 +10,6 @@ import {
   HostListener,
   HostBinding,
 } from '@angular/core';
-import {
-  trigger,
-  transition,
-  query,
-  style,
-  stagger,
-  animate,
-  keyframes,
-} from '@angular/animations';
 import { isDescendantOrSame } from '../../helpers/helpers';
 import { ColorFormats } from '../../enums/formats';
 import { ConverterService } from '../../services/converter.service';
@@ -32,53 +23,6 @@ import { NgxColorsColor } from '../../clases/color';
   selector: 'ngx-colors-panel',
   templateUrl: './panel.component.html',
   styleUrls: ['./panel.component.scss'],
-  animations: [
-    trigger('colorsAnimation', [
-      transition('void => slide-in', [
-        // Initially all colors are hidden
-        query(':enter', style({ opacity: 0 }), { optional: true }),
-        //slide-in animation
-        query(
-          ':enter',
-          stagger('10ms', [
-            animate(
-              '.3s ease-in',
-              keyframes([
-                style({ opacity: 0, transform: 'translatex(-50%)', offset: 0 }),
-                style({
-                  opacity: 0.5,
-                  transform: 'translatex(-10px) scale(1.1)',
-                  offset: 0.3,
-                }),
-                style({ opacity: 1, transform: 'translatex(0)', offset: 1 }),
-              ])
-            ),
-          ]),
-          { optional: true }
-        ),
-      ]),
-      //popup animation
-      transition('void => popup', [
-        query(':enter', style({ opacity: 0, transform: 'scale(0)' }), {
-          optional: true,
-        }),
-        query(
-          ':enter',
-          stagger('10ms', [
-            animate(
-              '500ms ease-out',
-              keyframes([
-                style({ opacity: 0.5, transform: 'scale(.5)', offset: 0.3 }),
-                style({ opacity: 1, transform: 'scale(1.1)', offset: 0.8 }),
-                style({ opacity: 1, transform: 'scale(1)', offset: 1 }),
-              ])
-            ),
-          ]),
-          { optional: true }
-        ),
-      ]),
-    ]),
-  ],
 })
 export class PanelComponent implements OnInit {
   @HostListener('document:mousedown', ['$event'])
@@ -109,7 +53,7 @@ export class PanelComponent implements OnInit {
   public previewColor: string = '#000000';
   public hsva = new Hsva(0, 1, 1, 1);
 
-  public colorsAnimationEffect = 'slide-in';
+  public colorsAnimationEffect: 'slide-in' | 'popup' = 'slide-in';
 
   public palette = defaultColors;
   public variants = [];
@@ -188,7 +132,7 @@ export class PanelComponent implements OnInit {
     triggerElementRef,
     color,
     palette,
-    animation,
+    animation: 'slide-in' | 'popup',
     format: string,
     hideTextInput: boolean,
     hideColorPicker: boolean,

--- a/projects/ngx-colors/src/lib/directives/ngx-colors-trigger.directive.spec.ts
+++ b/projects/ngx-colors/src/lib/directives/ngx-colors-trigger.directive.spec.ts
@@ -5,7 +5,6 @@ import { NgxColorsComponent } from '../ngx-colors.component';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 
 describe('NgxColorsTriggerDirective', () => {
@@ -64,11 +63,9 @@ describe('NgxColorsTriggerDirective', () => {
         const testHostComponent = TestHostComponent;
 
         beforeEach(async () => {
-            await TestBed.configureTestingModule({
-                providers: [
-                    provideNoopAnimations(),
-                ],
-            }).compileComponents();
+            // No animations provider is registered on purpose: ngx-colors must
+            // work without one now that the panel uses pure-CSS animations.
+            await TestBed.configureTestingModule({}).compileComponents();
 
             fixture = TestBed.createComponent(testHostComponent);
             hostComponent = fixture.componentInstance;
@@ -140,11 +137,9 @@ describe('NgxColorsTriggerDirective', () => {
         const testHostComponent = TestHostComponent;
 
         beforeEach(async () => {
-            await TestBed.configureTestingModule({
-                providers: [
-                    provideNoopAnimations(),
-                ],
-            }).compileComponents();
+            // No animations provider is registered on purpose: ngx-colors must
+            // work without one now that the panel uses pure-CSS animations.
+            await TestBed.configureTestingModule({}).compileComponents();
 
             fixture = TestBed.createComponent(testHostComponent);
             hostComponent = fixture.componentInstance;

--- a/projects/ngx-colors/src/lib/ngx-colors.module.ts
+++ b/projects/ngx-colors/src/lib/ngx-colors.module.ts
@@ -1,7 +1,6 @@
 import { NgModule } from "@angular/core";
 import { NgxColorsComponent } from "./ngx-colors.component";
 import { CommonModule } from "@angular/common";
-import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { ColorPickerComponent } from "./components/color-picker/color-picker.component";
 import { ConverterService } from "./services/converter.service";
 import { SliderDirective } from "./directives/slider.directive";


### PR DESCRIPTION
# fix: remove `@angular/animations` dependency

Closes #131

## Summary

The picker panel's enter animation was built on the legacy `@angular/animations` trigger API (`trigger('colorsAnimation', …)` with a synthetic `[@colorsAnimation]` template binding). Because a synthetic property requires an animations provider at bootstrap, every consuming app was forced to register one of `provideAnimations` / `provideAnimationsAsync` / `provideNoopAnimations` (or import `BrowserAnimationsModule`) — otherwise the app crashes at runtime with:

```
NG05105: Unexpected synthetic property @colorsAnimation found
```

This is increasingly painful for consumers: **`provideAnimationsAsync` is deprecated in Angular 20.2 and slated for removal in v23**, and all of the providers that satisfy synthetic properties live in the `@angular/animations` package, which is being phased out. The new `animate.enter` / `animate.leave` directives do **not** satisfy legacy `[@trigger]` properties, so the only durable fix is to stop using the trigger API inside the library.

This PR **reimplements the panel's enter animation in pure CSS**, so `ngx-colors` no longer depends on `@angular/animations` at all. Consuming apps can drop their animations provider, and the library drops a peer dependency.

**The visual animation is unchanged** — same `slide-in` / `popup` effects, same keyframe values, easing, durations, and the 10 ms-per-swatch stagger.

## Changes

- **`panel.component.ts`** — removed the `@angular/animations` import and the entire `animations: [ trigger('colorsAnimation', …) ]` metadata. Narrowed `colorsAnimationEffect` and the `iniciate()` `animation` parameter to `'slide-in' | 'popup'`.
- **`panel.component.html`** — replaced the synthetic `[@colorsAnimation]="colorsAnimationEffect"` binding on both `.colors` containers with an `[ngClass]` object toggle.
- **`panel.component.scss`** — reimplemented the `slide-in` / `popup` enter animations as native `@keyframes` applied to the direct children of `.colors`, with an `nth-child` stagger (SCSS `@for` loop) that reproduces the original 10 ms-per-item delay.
- **`ngx-colors.module.ts`** — removed a dead `BrowserAnimationsModule` import (it was never in the `imports` array).
- **`projects/ngx-colors/package.json`** — removed `@angular/animations` from `peerDependencies`.
- **`ngx-colors-trigger.directive.spec.ts`** — removed the now-unnecessary `provideNoopAnimations()` from the TestBed setups, so the panel-opening specs assert the picker works with **no** animations provider registered.

## How it works

`colorsAnimationEffect` (`'slide-in' | 'popup'`, set from the existing `colorsAnimation` input) is bound as a CSS class on the `.colors` container. The keyframes animate the container's direct children, and per-child `animation-delay`s recreate the stagger. Because the `.colors` container is created via `*ngIf` each time a menu/panel opens, the CSS animation restarts from `0%` automatically — matching the original `void => …` enter trigger behaviour.

## Compatibility

- **No breaking API changes.** The `colorsAnimation` input and both `slide-in` / `popup` effects behave exactly as before.
- Consuming apps that only added an animations provider for `ngx-colors` can now remove it. Apps that use animations for their own reasons are unaffected.

## Testing

- `npm run build-lib` (production ng-packagr build) succeeds; the compiled `fesm2020` / `fesm2015` bundles contain **zero** `@angular/animations` references, and `dist/package.json` no longer lists the peer dependency.
- `ng test ngx-colors` — the form-integration specs (which open the panel and select a swatch) pass with **no** animations provider registered, confirming the consumer requirement is gone.
- The CSS keyframes are a 1:1 port of the original Angular animation definition (same offsets, easing, durations, and stagger), so the rendered effect is preserved.
